### PR TITLE
feat(nav): add localization to nav

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -175,7 +175,20 @@ async function buildBreadcrumbs() {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
+  let navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
+  
+  // Check for localized nav fragments
+  if (!navMeta) {
+    const { pathname } = window.location;
+    const pathSegments = pathname.split('/').filter(Boolean);
+    
+    // If path starts with a language code (e.g., /de/, /fr/, /es/)
+    if (pathSegments.length > 0 && pathSegments[0].length === 2) {
+      const locale = pathSegments[0];
+      navPath = `/${locale}/nav`;
+    }
+  }
+  
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM


### PR DESCRIPTION

This pull request improves the navigation fragment loading logic in the `blocks/header/header.js` file to better support localized navigation. The main change is to dynamically select the navigation fragment based on the language code present in the URL, ensuring users see the correct navigation for their locale.

Localization support:

* Updated the logic in the `buildBreadcrumbs` function to detect language codes in the URL path and load the corresponding localized navigation fragment, such as `/de/nav` for German or `/fr/nav` for French.

Fix #11

Test URLs:
- Before: https://main--da-edge--twhite313.aem.live
- After: https://navupdate--da-edge--twhite313.aem.live

