### PR TITLE
fix(nav): fix url decorate

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -211,6 +211,7 @@ function decorateLinks(element) {
         }
       } catch (e) {
         // Invalid URL, skip
+        console.warn(`Invalid URL in link: "${link.href}". Error:`, e);
       }
     }
   }


### PR DESCRIPTION
Fix #20 

Test URLs:
- Before: https://main--da-edge--twhite313.aem.live/de/
- After: https://localize--da-edge--twhite313.aem.live/de/


This pull request introduces a new feature to automatically add locale prefixes to internal links within the main content area. The main changes involve the addition of a new function to process and update links, and its integration into the main decoration workflow.

New locale-aware link handling:

* Added a `decorateLinks` function to scan all anchor tags within a given element and update their `href` attributes to include locale prefixes for internal links, using the `localizeUrl` helper.
* Integrated the `decorateLinks` function into the `decorateMain` workflow so that all links within the main content are automatically localized during decoration.